### PR TITLE
mask_alignment_using_vcf.py - error when reference sequence not found

### DIFF
--- a/src/mask_alignment_using_vcf.py
+++ b/src/mask_alignment_using_vcf.py
@@ -31,6 +31,7 @@ def read_fasta_keep_name(file, cli_args):
     sample_sequences = []
     line_count = 0
     line = file.readline()
+    ref_index = None
     while line != "" and line != "\n":
         if line[0] == ">":
             name = line.replace("\n","").replace(">","")
@@ -49,6 +50,10 @@ def read_fasta_keep_name(file, cli_args):
             print("problem with fasta format: line not recognised")
             print(line)
             exit()
+    if ref_index is None:
+        print("reference sequence ID not found:")
+        print(cli_args.reference_id)
+        exit()
     return sample_headers, sample_sequences, ref_index
 
 


### PR DESCRIPTION
the `mask_alignment_using_vcf.py` throws an uninformative error if the reference sequence does not exist in the FASTA file. 

Here's a reproducible example:

```bash
wget https://raw.githubusercontent.com/W-L/ProblematicSites_SARS-CoV2/master/data/SARS-CoV-2.fa

python mask_alignment_using_vcf.py -v problematic_sites_sarsCov2.vcf -i SARS-CoV-2.fa -r "non-existent" -o test_masked.fa
```

throws this error:

```
UnboundLocalError: local variable 'ref_index' referenced before assignment
```

I think the pull request should fix this without breaking anything else. 